### PR TITLE
Fixed Bengali Probhat layout, replaced duplicate keys with missing keys

### DIFF
--- a/java/res/xml/rowkeys_probhat1.xml
+++ b/java/res/xml/rowkeys_probhat1.xml
@@ -34,13 +34,13 @@
                 latin:keyLabel="&#x0988;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
-                latin:keyLabel="&#x0988;"
+                latin:keyLabel="&#x09DC;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keyLabel="&#x09A0;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
-                latin:keyLabel="&#x09A0;"
+                latin:keyLabel="&#x0990;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keyLabel="&#x0989;"


### PR DESCRIPTION
Changed duplicate keys ঈ and ঠ for Probhat layout. The current version of Probhat keybpard of Indic-Keyboard contains "ধ ঊ ঈ ঈ ঠ ঠ উ ই ঔ ফ", which should be "ধ ঊ ঈ ড় ঠ ঐ উ ই ঔ ফ". Key for ড় and ঐ was missing. I replaced the duplicate keys with the missing keys.

Take a look at the official site of Probhat layout. http://ekushey.org/?page/probhat_layout
And here is an image of current buggy layout. http://i.imgur.com/CFotSBQ.png