### PR TITLE
take the package name from the context. 

### DIFF
--- a/java/src/com/android/inputmethod/latin/utils/DictionaryInfoUtils.java
+++ b/java/src/com/android/inputmethod/latin/utils/DictionaryInfoUtils.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 import org.smc.inputmethod.indic.AssetFileAddress;
 import org.smc.inputmethod.indic.BinaryDictionaryGetter;
 import org.smc.inputmethod.indic.Constants;
-import org.smc.inputmethod.indic.R;
 import org.smc.inputmethod.indic.settings.SpacingAndPunctuations;
 
 /**
@@ -44,7 +43,6 @@ import org.smc.inputmethod.indic.settings.SpacingAndPunctuations;
  */
 public class DictionaryInfoUtils {
     private static final String TAG = DictionaryInfoUtils.class.getSimpleName();
-    private static final String RESOURCE_PACKAGE_NAME = R.class.getPackage().getName();
     private static final String DEFAULT_MAIN_DICT = "main";
     private static final String MAIN_DICT_PREFIX = "main_";
     // 6 digits - unicode is limited to 21 bits
@@ -231,24 +229,26 @@ public class DictionaryInfoUtils {
     /**
      * Helper method to return a dictionary res id for a locale, or 0 if none.
      * @param locale dictionary locale
+     * @param packageName
      * @return main dictionary resource id
      */
     public static int getMainDictionaryResourceIdIfAvailableForLocale(final Resources res,
-            final Locale locale) {
+                                                                      final Locale locale,
+                                                                      final String packageName) {
         int resId;
         // Try to find main_language_country dictionary.
         if (!locale.getCountry().isEmpty()) {
             final String dictLanguageCountry =
                     MAIN_DICT_PREFIX + locale.toString().toLowerCase(Locale.ROOT);
             if ((resId = res.getIdentifier(
-                    dictLanguageCountry, "raw", RESOURCE_PACKAGE_NAME)) != 0) {
+                    dictLanguageCountry, "raw", packageName)) != 0) {
                 return resId;
             }
         }
 
         // Try to find main_language dictionary.
         final String dictLanguage = MAIN_DICT_PREFIX + locale.getLanguage();
-        if ((resId = res.getIdentifier(dictLanguage, "raw", RESOURCE_PACKAGE_NAME)) != 0) {
+        if ((resId = res.getIdentifier(dictLanguage, "raw", packageName)) != 0) {
             return resId;
         }
 
@@ -261,10 +261,10 @@ public class DictionaryInfoUtils {
      * @param locale dictionary locale
      * @return main dictionary resource id
      */
-    public static int getMainDictionaryResourceId(final Resources res, final Locale locale) {
-        int resourceId = getMainDictionaryResourceIdIfAvailableForLocale(res, locale);
+    public static int getMainDictionaryResourceId(final Resources res, final Locale locale, final String packageName) {
+        int resourceId = getMainDictionaryResourceIdIfAvailableForLocale(res, locale, packageName);
         if (0 != resourceId) return resourceId;
-        return res.getIdentifier(DEFAULT_MAIN_DICT, "raw", RESOURCE_PACKAGE_NAME);
+        return res.getIdentifier(DEFAULT_MAIN_DICT, "raw", packageName);
     }
 
     /**
@@ -368,7 +368,7 @@ public class DictionaryInfoUtils {
             final Locale locale = LocaleUtils.constructLocaleFromString(localeString);
             final int resourceId =
                     DictionaryInfoUtils.getMainDictionaryResourceIdIfAvailableForLocale(
-                            context.getResources(), locale);
+                            context.getResources(), locale, context.getPackageName());
             if (0 == resourceId) continue;
             final AssetFileAddress fileAddress =
                     BinaryDictionaryGetter.loadFallbackResource(context, resourceId);

--- a/java/src/org.smc.inputmethod/indic/BinaryDictionaryGetter.java
+++ b/java/src/org.smc.inputmethod/indic/BinaryDictionaryGetter.java
@@ -292,7 +292,7 @@ final public class BinaryDictionaryGetter {
 
         if (!foundMainDict && dictPackSettings.isWordListActive(mainDictId)) {
             final int fallbackResId =
-                    DictionaryInfoUtils.getMainDictionaryResourceId(context.getResources(), locale);
+                    DictionaryInfoUtils.getMainDictionaryResourceId(context.getResources(), locale, context.getPackageName());
             final AssetFileAddress fallbackAsset = loadFallbackResource(context, fallbackResId);
             if (null != fallbackAsset) {
                 fileList.add(fallbackAsset);

--- a/java/src/org.smc.inputmethod/indic/DictionaryFactory.java
+++ b/java/src/org.smc.inputmethod/indic/DictionaryFactory.java
@@ -150,7 +150,7 @@ public final class DictionaryFactory {
         AssetFileDescriptor afd = null;
         try {
             final int resId = DictionaryInfoUtils.getMainDictionaryResourceIdIfAvailableForLocale(
-                    context.getResources(), locale);
+                    context.getResources(), locale, context.getPackageName());
             if (0 == resId) return null;
             afd = context.getResources().openRawResourceFd(resId);
             if (afd == null) {
@@ -209,6 +209,6 @@ public final class DictionaryFactory {
     public static boolean isDictionaryAvailable(Context context, Locale locale) {
         final Resources res = context.getResources();
         return 0 != DictionaryInfoUtils.getMainDictionaryResourceIdIfAvailableForLocale(
-                res, locale);
+                res, locale, context.getPackageName());
     }
 }


### PR DESCRIPTION
Motivation:
I was trying to build an app with a different application-id to distribute my changes to my friends. and the app was crashing because it couldnt find dictionary resources. When I dig into it, I found that we are kind of hardcoding the package name in `DictionaryInfoUtils`. 

Changes:
With this fix, we accept packageName as another parameter and use it when searching for a resource. If you prefer, we could pass `context` directly instead of taking two parameters (`Resources` and `packageName`).

And we can easily override application-id to something otherthan `org.smc.inputmethod.indic` in build.gradle. 
