### PR TITLE
Fix user submitted bugs #54 #26

### DIFF
--- a/java/res/xml-sw600dp/key_period.xml
+++ b/java/res/xml-sw600dp/key_period.xml
@@ -25,14 +25,14 @@
     <!-- Kept as a separate file for cleaner overriding by an overlay.  -->
     <switch>
         <case
-            latin:languageCode="hi"
-            latin:keyboardLayoutSet="hindi_compact"
+            latin:languageCode="hi|bn"
+            latin:keyboardLayoutSet="hindi|qwerty"
         >
             <!-- U+0964: "।" DEVANAGARI DANDA -->
             <Key
                 latin:keySpec="\u0964"
                 latin:keyLabelFlags="hasPopupHint"
-                latin:moreKeys="!autoColumnOrder!8,\\,,.,',#,),(,/,;,@,:,-,&quot;,+,\\%,&amp;"
+                latin:moreKeys="!autoColumnOrder!8,\\,,.,',#,॥,),(,/,;,@,:,-,&quot;,+,\\%,&amp;"
                 latin:backgroundType="functional" />
         </case>
         <case

--- a/java/res/xml/key_period.xml
+++ b/java/res/xml/key_period.xml
@@ -23,14 +23,14 @@
 >
     <switch>
         <case
-            latin:languageCode="hi"
-            latin:keyboardLayoutSet="hindi_compact"
+            latin:languageCode="hi|bn"
+            latin:keyboardLayoutSet="hindi|qwerty"
         >
             <!-- U+0964: "।" DEVANAGARI DANDA -->
             <Key
                 latin:keySpec="\u0964"
                 latin:keyLabelFlags="hasPopupHint"
-                latin:moreKeys="!autoColumnOrder!9,\\,,.,?,!,#,),(,/,;,',@,:,-,&quot;,+,\\%,&amp;"
+                latin:moreKeys="!autoColumnOrder!9,\\,,.,?,!,#,॥,),(,/,;,',@,:,-,&quot;,+,\\%,&amp;"
                 latin:backgroundType="functional" />
         </case>
         <case


### PR DESCRIPTION
Fixed:
Bengali Dari is missing #54
DEVANAGARI DANDA instead of full stop in Hindi #26

Add Double Daari (॥) symbol to popup suggestions for Daari.
The position after # was chosen because its close enough to access for Bengali users while not getting in the way of hindi users.

(Old PR [here](https://github.com/smc/Indic-Keyboard/pull/58), closed due to force push. 
Created a new pull request because I force pushed to remove previous ~80 lines of code and new layout files that were created in attempt to fix this bug.
Now the fix is simplified to only a few additions. But old PR can't be reopened )

@jishnu7 Please take a look.