### PR TITLE
Add missing Bengali characters

### DIFF
--- a/java/res/xml/rowkeys_probhat1.xml
+++ b/java/res/xml/rowkeys_probhat1.xml
@@ -38,12 +38,18 @@
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keySpec="&#x09A0;"
+                latin:keyHintLabel="&#x09F3;"
+                latin:additionalMoreKeys="&#x09F3;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keySpec="&#x0990;"
+                latin:keyHintLabel="&#x099E;"
+                latin:additionalMoreKeys="&#x099E;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keySpec="&#x0989;"
+                latin:keyHintLabel="&#x09CE;"
+                latin:additionalMoreKeys="&#x09CE;"
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keySpec="&#x0987;"

--- a/java/res/xml/rowkeys_probhat2.xml
+++ b/java/res/xml/rowkeys_probhat2.xml
@@ -57,6 +57,7 @@
                 latin:keyLabelFlags="fontNormal" />
             <Key
                 latin:keySpec="!icon/zwnj_key|&#x200C;"
+                latin:additionalMoreKeys="&#x200D;"
                 latin:keyLabelFlags="fontNormal" />
         </case>
 


### PR DESCRIPTION
Probhat layout comes with the following keys in number row [Wikipedia](https://en.wikipedia.org/wiki/Bengali_input_methods#/media/File:KB-Bengali-Probhat.svg).

![37643966-65471572-2c4c-11e8-8631-dc5e422a82d6](https://user-images.githubusercontent.com/1847242/37644310-950a59c6-2c4d-11e8-9a1d-c3ae984db082.png)

The number row has only 4 keys that are needed for typing in Bengali. They are 0x09F3 (৳), 0x099E (ঞ), 0x09CE (ৎ) and ZWJ. As Indic Keyboard has a common number key layout for all Bengali layouts (Probhat, Avro etc), so I added those missing keys as `additionalMoreKeys` in 1st row of Probhat layout and left Numeric layout untouched.

Here is how it looks.

![screenshot_20180320-130720](https://user-images.githubusercontent.com/1847242/37643921-4993c988-2c4c-11e8-9875-e73430019fff.png)

I also added ZWJ (which is very important for typing some Bengali words like র‍্যাব) as `additionalMoreKeys` for key ZWNJ.

I hope my submission will be accepted and merged. Thanks.