### PR TITLE
Remove 0x09CD as keyspec_comma for as_IN and bn_IN keyboards

### DIFF
--- a/java/src/com/android/inputmethod/keyboard/internal/KeyboardTextsTable.java
+++ b/java/src/com/android/inputmethod/keyboard/internal/KeyboardTextsTable.java
@@ -494,7 +494,7 @@ public final class KeyboardTextsTable {
         /* keyspec_symbols_9 */ "\u09EF",
         /* keyspec_symbols_0 */ "\u09E6",
         /* keylabel_to_symbol */ "\u09E7\u09E8\u09E9",
-        /* keyspec_comma */ "\u09CD",
+        /* keyspec_comma */ ",",
         /* morekeys_a ~ */
         null, null, null, null, null, null, null, null,
         /* ~ morekeys_c */
@@ -526,7 +526,7 @@ public final class KeyboardTextsTable {
         /* keyspec_symbols_9 */ "\u09EF",
         /* keyspec_symbols_0 */ "\u09E6",
         /* keylabel_to_symbol */ "\u09E7\u09E8\u09E9",
-        /* keyspec_comma */ "\u09CD",
+        /* keyspec_comma */ ",",
         /* morekeys_a ~ */
         null, null, null, null, null, null, null, null,
         /* ~ morekeys_c */


### PR DESCRIPTION
Hi SMC Team,

This is my **3rd** PR for Indic Keyboard. Feeling great to contribute.

Anyway, for the latest release, I found that the "Bengali - Probhat" layout has a wrong key instead of Comma `,` (right beside the language switch key). The character `0x09CD` (BENGALI SIGN VIRAMA) is used to join two or more characters into a single composite character which is obviously not a comma key.

![Screenshot_20200805-034255_Keep_notes](https://user-images.githubusercontent.com/1847242/89338900-dba7c100-d6cf-11ea-8d7d-619636a5d495.png)

This PR fixes the wrongly places comma for `as_IN` and `bn_IN` layout.

![Screenshot_20200805-034124_Keep_notes](https://user-images.githubusercontent.com/1847242/89338906-dea2b180-d6cf-11ea-8547-e87a7f0b72b3.png)
